### PR TITLE
Update last page to refer to GCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -635,9 +635,9 @@ app/guid-2  unresponsive agent  10.244.0.2
     
     <div class="section last"><div class="center-column"><h1>Done!</h1>
 
-<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed services, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered from a failing service, failing VM and failing deploy.</p>
+<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed a release, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered a failing service, failing VM and failing deploy.</p>
 
-<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). YOu can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
+<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). You can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
 
 <p>Learn more:
 <ul>

--- a/index.html
+++ b/index.html
@@ -635,13 +635,14 @@ app/guid-2  unresponsive agent  10.244.0.2
     
     <div class="section last"><div class="center-column"><h1>Done!</h1>
 
-<p>In this tutorial we used BOSH to deploy services, updated our deployment with source changes, scaled the number of services and changed their properties. We recovered from failing service, failing VM and failing deploy.</p>
+<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed services, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered from a failing service, failing VM and failing deploy.</p>
 
-<p>We were using VirtualBox environment with Warden CPI (Cloud Provider Interface). Warden is a Linux container management tool and Warden CPI abstracts VMs as Linux containers. The Director can work with any CPI that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere and vCloud. Read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
+<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). YOu can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
 
 <p>Learn more:
 <ul>
-<li><a href="https://bosh.io/docs">bosh.io: Docs</a></li>
+  <li><a href="https://bosh.io/docs">bosh.io: Docs</a></li>
+</ul>
 </p>
 </div></div>
     

--- a/sections/done.html
+++ b/sections/done.html
@@ -1,10 +1,11 @@
 <h1>Done!</h1>
 
-<p>In this tutorial we used BOSH to deploy services, updated our deployment with source changes, scaled the number of services and changed their properties. We recovered from failing service, failing VM and failing deploy.</p>
+<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed services, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered from a failing service, failing VM and failing deploy.</p>
 
-<p>We were using VirtualBox environment with Warden CPI (Cloud Provider Interface). Warden is a Linux container management tool and Warden CPI abstracts VMs as Linux containers. The Director can work with any CPI that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere and vCloud. Read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
+<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). YOu can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
 
 <p>Learn more:
 <ul>
-<li><a href="https://bosh.io/docs">bosh.io: Docs</a></li>
+  <li><a href="https://bosh.io/docs">bosh.io: Docs</a></li>
+</ul>
 </p>

--- a/sections/done.html
+++ b/sections/done.html
@@ -1,8 +1,8 @@
 <h1>Done!</h1>
 
-<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed services, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered from a failing service, failing VM and failing deploy.</p>
+<p>In this tutorial we created a BOSH Bastion in Google Cloud Platform and used the BOSH CLI on that bastion to create a BOSH Director. We deployed a release, updated our deployment with source changes, scaled the number of services and changed their properties on that BOSH Director. We also recovered a failing service, failing VM and failing deploy.</p>
 
-<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). YOu can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
+<p>The BOSH Director can work with any CPI (Cloud Provider Interface) that implements a certain API to manage IaaS resources. There are several supported CPIs for different IaaS providers: AWS, GCP, Openstack, vSphere, vCloud and VirtualBox (a.k.a. BOSH Lite). You can read more about CPIs here: <a href="http://bosh.io/docs/cpi-api-v1.html">http://bosh.io/docs/cpi-api-v1.html</a>.</p>
 
 <p>Learn more:
 <ul>


### PR DESCRIPTION
Last page erroneously refers to VirtualBox (BOSH Lite) and not GCP